### PR TITLE
[fix/#4] Revert theme fonts to hardcoded and use Inter as default

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -185,6 +185,7 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist_Mono, Inter } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -24,9 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${inter.variable} ${geistMono.variable} antialiased`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Background

- PR: #4

As in https://github.com/Orb-H/chracl-rating-dashboard/pull/4#discussion_r2658034109, Github Copilot suggested using variables of `--font-geist-sans` and `--font-geist-mono` instead of hardcoded font list. However, the variables `--font-geist-sans` and `--font-geist-mono` was not effective of `@theme inline` part, so it was not rendered well on the website.

## Changes

- Revert `--font-sans` and `--font-mono` variable in inline theme to hardcoded fonts
- Use Inter as a default font instead of Geist Sans