### PR TITLE
[#9] Rename sidebar items for more intuitivity

### DIFF
--- a/components/MySidebar.tsx
+++ b/components/MySidebar.tsx
@@ -61,7 +61,7 @@ export function MySidebar() {
                 <SidebarMenuButton asChild>
                   <Link href="#">
                     <TrophyIcon className="inline" />{" "}
-                    <span>리더보드 (준비중)</span>
+                    <span>레이팅 리더보드 (준비중)</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -105,7 +105,7 @@ export function MySidebar() {
                 <SidebarMenuButton asChild>
                   <Link href="#">
                     <BrainIcon className="inline" />{" "}
-                    <span>레이팅 기반 예측 (준비중)</span>
+                    <span>가상 대결 예측 (준비중)</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -113,7 +113,7 @@ export function MySidebar() {
                 <SidebarMenuButton asChild>
                   <Link href="#">
                     <ScrollTextIcon className="inline" />{" "}
-                    <span>업데이트 로그 (준비중)</span>
+                    <span>업데이트 내역 (준비중)</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>


### PR DESCRIPTION
## Background

- Issue: #9

## Changes

- Rename `리더보드` to `레이팅 리더보드`
- Rename `레이팅 기반 예측` to `가상 대결 예측`
- Rename `업데이트 로그` to `업데이트 내역`