### PR TITLE
[#67] Unify background classNames

### DIFF
--- a/app/competitions/page.tsx
+++ b/app/competitions/page.tsx
@@ -7,7 +7,7 @@ export default function Competitions() {
   const competitions = competitionIds.map(loadCompetitionById);
 
   return (
-    <main className="flex flex-col min-h-screen w-full max-w-3xl mx-auto items-center py-16 px-8 md:py-32 md:px-16 bg-white dark:bg-black md:items_start">
+    <main className="flex flex-col min-h-screen w-full max-w-3xl mx-auto items-center py-16 px-8 md:py-32 md:px-16 bg-background md:items_start">
       <header className="mb-8 w-full">
         <h1 className="text-4xl font-bold">대회 목록</h1>
         <p className="mt-2 text-lg text-muted-foreground">

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -34,7 +34,7 @@ export default function Leaderboard() {
     .sort((a, b) => b.value - a.value);
 
   return (
-    <main className="flex flex-col min-h-screen w-full max-w-3xl mx-auto items-center py-16 px-8 md:py-32 md:px-16 bg-white dark:bg-black md:items_start">
+    <main className="flex flex-col min-h-screen w-full max-w-3xl mx-auto items-center py-16 px-8 md:py-32 md:px-16 bg-background md:items_start">
       <header className="mb-8 w-full">
         <h1 className="text-4xl font-bold">레이팅 리더보드</h1>
         <p className="mt-2 text-lg text-muted-foreground">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-16 px-8 md:py-32 md:px-16 bg-white dark:bg-black md:items_start">
+    <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-16 px-8 md:py-32 md:px-16 bg-background md:items_start">
       <Image
         className="dark:invert"
         src="/next.svg"

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function Participants() {
   return (
-    <main className="min-h-screen w-full max-w-3xl items-center py-16 px-8 md:py-32 md:px-16 bg-white dark:bg-black md:items_start">
+    <main className="min-h-screen w-full max-w-3xl items-center py-16 px-8 md:py-32 md:px-16 bg-background md:items_start">
       {/* TODO(#10): Fill with concrete content */}
       <Empty>
         <EmptyHeader>

--- a/app/rating-intro/page.tsx
+++ b/app/rating-intro/page.tsx
@@ -105,7 +105,7 @@ const ShadcnTypographyRenderer = {
 
 export default function RatingIntro() {
   return (
-    <main className="min-h-screen w-full max-w-3xl items-center py-16 px-8 md:py-32 md:px-16 bg-white dark:bg-black md:items_start">
+    <main className="min-h-screen w-full max-w-3xl items-center py-16 px-8 md:py-32 md:px-16 bg-background md:items_start">
       <Markdown
         remarkPlugins={[remarkGfm]}
         components={ShadcnTypographyRenderer as Components}


### PR DESCRIPTION
## Background

- Issue: #67
- Resolves #67

Such separation was due to manual background classNames, `bg-background` for outer part and `bg-white dark:bg-black` for inner part.

## Changes

- Replace all `bg-white dark:bg-black` occurrences to `bg-background`