### PR TITLE
[#40] Set leaderboard chart range dynamically

### DIFF
--- a/app/leaderboard/leaderboardChart.tsx
+++ b/app/leaderboard/leaderboardChart.tsx
@@ -38,18 +38,17 @@ export function LeaderboardChart({ ratingData }: LeaderboardChartProps) {
     }));
   const min =
     Math.min(
-      ...ratingData.map((player) =>
-        player.value && player.mu
-          ? Math.min(player.value, player.mu)
-          : Number.MAX_VALUE,
+      0,
+      ...chartData.map((player) =>
+        Math.min(Number(player.value), Number(player.mu)),
       ),
     ) - 5;
+
   const max =
     Math.max(
-      ...ratingData.map((player) =>
-        player.value && player.mu
-          ? Math.max(player.value, player.mu)
-          : Number.MIN_VALUE,
+      100,
+      ...chartData.map((player) =>
+        Math.max(Number(player.value), Number(player.mu)),
       ),
     ) + 5;
 


### PR DESCRIPTION
## Background

- Issue: #40

## Changes

- Make range of X-axis of leaderboard chart to (minimum rating - 5, maximum mu + 5)
- Set ticks to be always interval of 25 and include 0