### PR TITLE
[#51] Change team names of season 1 to official name 

### DIFF
--- a/data/competitions/season1.json
+++ b/data/competitions/season1.json
@@ -3,23 +3,23 @@
   "name": "제 1회 치지직 레이싱 동아리: 고속도로 배틀",
   "teams": [
     {
-      "id": "season1-team-a",
-      "name": "A팀",
+      "id": "season1-team-namgung-hyuk",
+      "name": "남궁혁",
       "members": ["namgung-hyuk", "odanming", "chochou"]
     },
     {
-      "id": "season1-team-b",
-      "name": "B팀",
+      "id": "season1-team-hyungdok",
+      "name": "형독",
       "members": ["hyungdok", "hamkubby", "reo"]
     },
     {
-      "id": "season1-team-c",
-      "name": "C팀",
+      "id": "season1-team-cheongalice",
+      "name": "강지형",
       "members": ["cheongalice", "oversleepzzz", "hera"]
     },
     {
-      "id": "season1-team-d",
-      "name": "D팀",
+      "id": "season1-team-yona",
+      "name": "요나",
       "members": ["yona", "a2-duck", "yang-mei"]
     }
   ],


### PR DESCRIPTION
## Background

- Issue: #51

## Changes

- Change team name of season 1 from team a-d to team namgung-hyuk, hyungdok, cheongalice, and yona