### PR TITLE
[#12] Change all `NONE` entryid occurrences to `initial`

### DIFF
--- a/data/histories/100hp-tv.json
+++ b/data/histories/100hp-tv.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/a2-duck.json
+++ b/data/histories/a2-duck.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/auro.json
+++ b/data/histories/auro.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/bbogumi.json
+++ b/data/histories/bbogumi.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/cheongalice.json
+++ b/data/histories/cheongalice.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/chochou.json
+++ b/data/histories/chochou.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/eaglekop.json
+++ b/data/histories/eaglekop.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/haematl.json
+++ b/data/histories/haematl.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/half.json
+++ b/data/histories/half.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/hamkubby.json
+++ b/data/histories/hamkubby.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/hera.json
+++ b/data/histories/hera.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/hyungdok.json
+++ b/data/histories/hyungdok.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/ichika-hibi.json
+++ b/data/histories/ichika-hibi.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/kanetv8.json
+++ b/data/histories/kanetv8.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/kevinstudio.json
+++ b/data/histories/kevinstudio.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/kim-toki.json
+++ b/data/histories/kim-toki.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/lotionyum.json
+++ b/data/histories/lotionyum.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/moon-hojun.json
+++ b/data/histories/moon-hojun.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/mytyl-maerchen.json
+++ b/data/histories/mytyl-maerchen.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/namgung-hyuk.json
+++ b/data/histories/namgung-hyuk.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/nodolly.json
+++ b/data/histories/nodolly.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/odanming.json
+++ b/data/histories/odanming.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/oversleepzzz.json
+++ b/data/histories/oversleepzzz.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/park-insoo.json
+++ b/data/histories/park-insoo.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/parkgee.json
+++ b/data/histories/parkgee.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/psy-haruto.json
+++ b/data/histories/psy-haruto.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/reana.json
+++ b/data/histories/reana.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/reo.json
+++ b/data/histories/reo.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/saessakgamja.json
+++ b/data/histories/saessakgamja.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/samozang.json
+++ b/data/histories/samozang.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/sdsd97.json
+++ b/data/histories/sdsd97.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/u-lili.json
+++ b/data/histories/u-lili.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/yang-mei.json
+++ b/data/histories/yang-mei.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/yona.json
+++ b/data/histories/yona.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/yu-yeonghyeok.json
+++ b/data/histories/yu-yeonghyeok.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,

--- a/data/histories/zen1th-hwang.json
+++ b/data/histories/zen1th-hwang.json
@@ -1,6 +1,6 @@
 [
   {
-    "entryId": "NONE",
+    "entryId": "initial",
     "rating": {
       "mu": 50,
       "sigma": 16.666666666666668,


### PR DESCRIPTION
## Background

- Issue: #12

Currently `initial` is set as entryId in entries, while `NONE` is set as entryId in rating histories

## Changes

- Replace all `NONE`s in rating histories to `initial`