### PR TITLE
[#11|#109] Add track information on player detail page

### DIFF
--- a/app/players/[id]/RecordList.tsx
+++ b/app/players/[id]/RecordList.tsx
@@ -1,0 +1,71 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Match } from "@/types/match";
+
+export function RecordList({ id, matches }: { id: string; matches: Match[] }) {
+  return (
+    <Table>
+      <TableHeader className="bg-muted">
+        <TableRow>
+          <TableHead className="p-2 leading-8">
+            <span>경기</span>
+            <br />
+            <span>트랙</span>
+          </TableHead>
+          <TableHead className="p-2 leading-8 text-end">
+            <span>기록</span>
+            <br />
+            <span>순위</span>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {matches.map((match) => {
+          const record = match.participants.find((p) => p.id === id);
+          if (!record) return null;
+
+          let time: string | undefined;
+          let penaltyTime: string | undefined;
+          if (match.type === "QUALIFYING") {
+            time = record.record.lapTime;
+          } else if (match.type === "MAIN") {
+            time = record.record.finishTime ?? "-";
+            if (record.record.penaltyTime) {
+              penaltyTime = `(+${record.record.penaltyTime})`;
+            }
+          }
+
+          return (
+            <TableRow key={match.id}>
+              <TableCell className="leading-8">
+                <span>
+                  {match.competitionId} {match.name}
+                </span>
+                <br />
+                <span className="text-sm text-muted-foreground">
+                  {match.trackName}
+                </span>
+              </TableCell>
+              <TableCell className="leading-8 text-end">
+                <span>{time ?? "-"}</span>
+                {penaltyTime && (
+                  <span className="text-destructive"> {penaltyTime}</span>
+                )}
+                <br />
+                <span className="text-sm text-muted-foreground">
+                  {record.place} / {match.participants.length}
+                </span>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/app/players/[id]/page.tsx
+++ b/app/players/[id]/page.tsx
@@ -16,6 +16,7 @@ import { Career } from "@/types/player";
 import { RatingHistory } from "@/types/rating";
 import { CollapsibleItem } from "./CollapsibleItem";
 import { RatingChart } from "./RatingChart";
+import { RecordList } from "./RecordList";
 
 export const dynamicParams = false;
 
@@ -130,7 +131,7 @@ export default async function Player({
         />
       </CollapsibleItem>
       <CollapsibleItem title="주행 기록">
-        <RecordItem id={id} matches={participatedMatches} />
+        <RecordList id={id} matches={participatedMatches} />
       </CollapsibleItem>
     </main>
   );
@@ -153,67 +154,5 @@ function CareerList({ career }: { career: Career[] }) {
         </li>
       ))}
     </ul>
-  );
-}
-
-function RecordItem({ id, matches }: { id: string; matches: Match[] }) {
-  return (
-    <Table>
-      <TableHeader className="bg-muted">
-        <TableRow>
-          <TableHead className="p-2 leading-8">
-            <span>경기</span>
-            <br />
-            <span>트랙</span>
-          </TableHead>
-          <TableHead className="p-2 leading-8 text-end">
-            <span>기록</span>
-            <br />
-            <span>순위</span>
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {matches.map((match) => {
-          const record = match.participants.find((p) => p.id === id);
-          if (!record) return null;
-
-          let time: string | undefined;
-          let penaltyTime: string | undefined;
-          if (match.type === "QUALIFYING") {
-            time = record.record.lapTime;
-          } else if (match.type === "MAIN") {
-            time = record.record.finishTime ?? "-";
-            if (record.record.penaltyTime) {
-              penaltyTime = `(+${record.record.penaltyTime})`;
-            }
-          }
-
-          return (
-            <TableRow key={match.id}>
-              <TableCell className="leading-8">
-                <span>
-                  {match.competitionId} {match.name}
-                </span>
-                <br />
-                <span className="text-sm text-muted-foreground">
-                  {match.trackName}
-                </span>
-              </TableCell>
-              <TableCell className="leading-8 text-end">
-                <span>{time ?? "-"}</span>
-                {penaltyTime && (
-                  <span className="text-destructive"> {penaltyTime}</span>
-                )}
-                <br />
-                <span className="text-sm text-muted-foreground">
-                  {record.place} / {match.participants.length}
-                </span>
-              </TableCell>
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
   );
 }


### PR DESCRIPTION
## Background

- Issue: #11, #109

## Changes

- Convert match record table to multi-line layout
- Add track information on the table
- Add destructive highlight on penalty time