### PR TITLE
[#51] Add missing ratedPlace values in season3 matches data

### DIFF
--- a/data/matches/season3/pre-a-qual.json
+++ b/data/matches/season3/pre-a-qual.json
@@ -10,51 +10,61 @@
     {
       "id": "hyungdok",
       "place": 1,
+      "ratedPlace": 2,
       "record": { "status": "FINISHED", "lapTime": "3:27.581" }
     },
     {
       "id": "yona",
       "place": 2,
+      "ratedPlace": 4,
       "record": { "status": "FINISHED", "lapTime": "3:30.383" }
     },
     {
       "id": "yu-yeonghyeok",
       "place": 3,
+      "ratedPlace": 9,
       "record": { "status": "FINISHED", "lapTime": "3:34.240" }
     },
     {
       "id": "hera",
       "place": 4,
+      "ratedPlace": 10,
       "record": { "status": "FINISHED", "lapTime": "3:34.715" }
     },
     {
       "id": "odanming",
       "place": 5,
+      "ratedPlace": 12,
       "record": { "status": "FINISHED", "lapTime": "3:35.715" }
     },
     {
       "id": "yang-mei",
       "place": 6,
+      "ratedPlace": 13,
       "record": { "status": "FINISHED", "lapTime": "3:36.800" }
     },
     {
       "id": "haematl",
       "place": 7,
+      "ratedPlace": 19,
       "record": { "status": "FINISHED", "lapTime": "3:38.602" }
     },
     {
       "id": "kevinstudio",
       "place": 8,
+      "ratedPlace": 20,
       "record": { "status": "FINISHED", "lapTime": "3:39.743" }
     },
     {
       "id": "auro",
       "place": 9,
+      "ratedPlace": 29,
       "record": { "status": "FINISHED", "lapTime": "3:51.822" }
     },
     {
       "id": "reana",
       "place": 10,
+      "ratedPlace": 30,
       "record": { "status": "FINISHED", "lapTime": "3:53.346" }
     }
   ]

--- a/data/matches/season3/pre-b-qual.json
+++ b/data/matches/season3/pre-b-qual.json
@@ -10,51 +10,61 @@
     {
       "id": "zen1th-hwang",
       "place": 1,
+      "ratedPlace": 3,
       "record": { "status": "FINISHED", "lapTime": "3:28.664" }
     },
     {
       "id": "cheongalice",
       "place": 2,
+      "ratedPlace": 7,
       "record": { "status": "FINISHED", "lapTime": "3:33.470" }
     },
     {
       "id": "100hp-tv",
       "place": 3,
+      "ratedPlace": 8,
       "record": { "status": "FINISHED", "lapTime": "3:33.856" }
     },
     {
       "id": "saessakgamja",
       "place": 4,
+      "ratedPlace": 14,
       "record": { "status": "FINISHED", "lapTime": "3:37.062" }
     },
     {
       "id": "bbogumi",
       "place": 5,
+      "ratedPlace": 15,
       "record": { "status": "FINISHED", "lapTime": "3:37.533" }
     },
     {
       "id": "psy-haruto",
       "place": 6,
+      "ratedPlace": 16,
       "record": { "status": "FINISHED", "lapTime": "3:37.709" }
     },
     {
       "id": "mytyl-maerchen",
       "place": 7,
+      "ratedPlace": 23,
       "record": { "status": "FINISHED", "lapTime": "3:43.339" }
     },
     {
       "id": "ichika-hibi",
       "place": 8,
+      "ratedPlace": 26,
       "record": { "status": "FINISHED", "lapTime": "3:46.814" }
     },
     {
       "id": "oversleepzzz",
       "place": 9,
+      "ratedPlace": 27,
       "record": { "status": "FINISHED", "lapTime": "3:46.891" }
     },
     {
       "id": "eaglekop",
       "place": 10,
+      "ratedPlace": 28,
       "record": { "status": "FINISHED", "lapTime": "3:46.906" }
     }
   ]

--- a/data/matches/season3/pre-c-qual.json
+++ b/data/matches/season3/pre-c-qual.json
@@ -10,51 +10,61 @@
     {
       "id": "namgung-hyuk",
       "place": 1,
+      "ratedPlace": 1,
       "record": { "status": "FINISHED", "lapTime": "3:27.287" }
     },
     {
       "id": "reo",
       "place": 2,
+      "ratedPlace": 5,
       "record": { "status": "FINISHED", "lapTime": "3:31.037" }
     },
     {
       "id": "samozang",
       "place": 3,
+      "ratedPlace": 6,
       "record": { "status": "FINISHED", "lapTime": "3:31.048" }
     },
     {
       "id": "kim-toki",
       "place": 4,
+      "ratedPlace": 11,
       "record": { "status": "FINISHED", "lapTime": "3:35.152" }
     },
     {
       "id": "chochou",
       "place": 5,
+      "ratedPlace": 17,
       "record": { "status": "FINISHED", "lapTime": "3:37.839" }
     },
     {
       "id": "a2-duck",
       "place": 6,
+      "ratedPlace": 18,
       "record": { "status": "FINISHED", "lapTime": "3:38.081" }
     },
     {
       "id": "sdsd97",
       "place": 7,
+      "ratedPlace": 21,
       "record": { "status": "FINISHED", "lapTime": "3:39.939" }
     },
     {
       "id": "lotionyum",
       "place": 8,
+      "ratedPlace": 22,
       "record": { "status": "FINISHED", "lapTime": "3:40.292" }
     },
     {
       "id": "u-lili",
       "place": 9,
+      "ratedPlace": 24,
       "record": { "status": "FINISHED", "lapTime": "3:44.733" }
     },
     {
       "id": "half",
       "place": 10,
+      "ratedPlace": 25,
       "record": { "status": "FINISHED", "lapTime": "3:46.191" }
     }
   ]


### PR DESCRIPTION
## Background

- Issue: #51

## Changes

- Add missing `ratedPlace` values in season3 matches data, specifically for preliminary stage
