### PR TITLE
[#51] Replace all "본선" with "레이스"

### DIFF
--- a/data/matches/season1/round1-main.json
+++ b/data/matches/season1/round1-main.json
@@ -2,7 +2,7 @@
   "id": "round1-main",
   "competitionId": "season1",
   "entryId": "season1-round1-main",
-  "name": "라운드 1 본선",
+  "name": "라운드 1 레이스",
   "date": "2025-04-27",
   "type": "MAIN",
   "trackName": "그랜드 밸리 하이웨이 1 (낮)",

--- a/data/matches/season1/round2-main.json
+++ b/data/matches/season1/round2-main.json
@@ -2,7 +2,7 @@
   "id": "round2-main",
   "competitionId": "season1",
   "entryId": "season1-round2-main",
-  "name": "라운드 2 본선",
+  "name": "라운드 2 레이스",
   "date": "2025-04-27",
   "type": "MAIN",
   "trackName": "도쿄 익스프레스웨이 남쪽 내주 (밤)",

--- a/data/matches/season2/final-main.json
+++ b/data/matches/season2/final-main.json
@@ -2,7 +2,7 @@
   "id": "final-main",
   "competitionId": "season2",
   "entryId": "season2-final-main",
-  "name": "결승전 본선",
+  "name": "결승전 레이스",
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "몬차 서킷 (시케인 없음)",

--- a/data/matches/season2/pre-a-main.json
+++ b/data/matches/season2/pre-a-main.json
@@ -2,7 +2,7 @@
   "id": "pre-a-main",
   "competitionId": "season2",
   "entryId": "season2-pre-a-main",
-  "name": "예선 A조 본선",
+  "name": "예선 A조 레이스",
   "date": "2025-06-29",
   "type": "MAIN",
   "trackName": "레드불 링",

--- a/data/matches/season2/pre-b-main.json
+++ b/data/matches/season2/pre-b-main.json
@@ -2,7 +2,7 @@
   "id": "pre-b-main",
   "competitionId": "season2",
   "entryId": "season2-pre-b-main",
-  "name": "예선 B조 본선",
+  "name": "예선 B조 레이스",
   "date": "2025-06-29",
   "type": "MAIN",
   "trackName": "레드불 링",

--- a/data/matches/season2/semifinal-a-main.json
+++ b/data/matches/season2/semifinal-a-main.json
@@ -2,7 +2,7 @@
   "id": "semifinal-a-main",
   "competitionId": "season2",
   "entryId": "season2-semifinal-a-main",
-  "name": "4강 A조 본선",
+  "name": "4강 A조 레이스",
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "레드불 링",

--- a/data/matches/season2/semifinal-b-main.json
+++ b/data/matches/season2/semifinal-b-main.json
@@ -2,7 +2,7 @@
   "id": "semifinal-b-main",
   "competitionId": "season2",
   "entryId": "season2-semifinal-b-main",
-  "name": "4강 B조 본선",
+  "name": "4강 B조 레이스",
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "레드불 링",

--- a/data/matches/season2/third-main.json
+++ b/data/matches/season2/third-main.json
@@ -2,7 +2,7 @@
   "id": "third-main",
   "competitionId": "season2",
   "entryId": "season2-third-main",
-  "name": "3·4위 결정전 본선",
+  "name": "3·4위 결정전 레이스",
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "몬차 서킷 (시케인 없음)",

--- a/data/matches/season3/stint1-main.json
+++ b/data/matches/season3/stint1-main.json
@@ -2,7 +2,7 @@
   "id": "stint1-main",
   "competitionId": "season3",
   "entryId": "season3-stint1-main",
-  "name": "STINT 1 본선",
+  "name": "STINT 1 레이스",
   "date": "2025-11-23",
   "type": "MAIN",
   "trackName": "라 사르트 서킷 (낮, 맑음)",

--- a/data/matches/season3/stint2-main.json
+++ b/data/matches/season3/stint2-main.json
@@ -2,7 +2,7 @@
   "id": "stint2-main",
   "competitionId": "season3",
   "entryId": "season3-stint2-main",
-  "name": "STINT 2 본선",
+  "name": "STINT 2 레이스",
   "date": "2025-11-23",
   "type": "MAIN",
   "trackName": "라 사르트 서킷 (낮→밤, 맑음→비)",

--- a/data/matches/season3/stint3-main.json
+++ b/data/matches/season3/stint3-main.json
@@ -2,7 +2,7 @@
   "id": "stint3-main",
   "competitionId": "season3",
   "entryId": "season3-stint3-main",
-  "name": "STINT 3 본선",
+  "name": "STINT 3 레이스",
   "date": "2025-11-23",
   "type": "MAIN",
   "trackName": "라 사르트 서킷 (밤→낮, 비→맑음)",


### PR DESCRIPTION
## Background

- Issue: #51

## Changes

- Replace all occurrences of "본선" with "레이스"
  - It is a formal term to use "레이스"