### PR TITLE
[#128] Rename season4 competition to 챔피언"쉽"

### DIFF
--- a/data/competitions/season4.json
+++ b/data/competitions/season4.json
@@ -1,7 +1,7 @@
 {
   "id": "season4",
-  "name": "제 4회 치지직 레이싱 동아리: 포뮬러 챔피언십",
-  "shortName": "제 4회: 포뮬러 챔피언십",
+  "name": "제 4회 치지직 레이싱 동아리: 포뮬러 챔피언쉽",
+  "shortName": "제 4회: 포뮬러 챔피언쉽",
   "sortOrder": 4,
   "teams": [],
   "pointsSchemes": {}


### PR DESCRIPTION
## Background

- Issue: #128 

In Namuwiki, the title of the document has been changed from 챔피언"십" to 챔피언"쉽". The data in this repo should also be changed to follow that name.

## Changes

- Rename season4 competition from `제 4회 치지직 레이싱 동아리: 포뮬러 챔피언십` to `제 4회 치지직 레이싱 동아리: 포뮬러 챔피언쉽`
