### PR TITLE
[#51] Include competition id in match id

### DIFF
--- a/data/matches/season1/round1-main.json
+++ b/data/matches/season1/round1-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "round1-main",
+  "id": "season1-round1-main",
   "competitionId": "season1",
   "entryId": "season1-round1-main",
   "name": "라운드 1 레이스",

--- a/data/matches/season1/round1-qual.json
+++ b/data/matches/season1/round1-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "round1-qual",
+  "id": "season1-round1-qual",
   "competitionId": "season1",
   "entryId": "season1-round1-qual",
   "name": "라운드 1 퀄리파잉",

--- a/data/matches/season1/round2-main.json
+++ b/data/matches/season1/round2-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "round2-main",
+  "id": "season1-round2-main",
   "competitionId": "season1",
   "entryId": "season1-round2-main",
   "name": "라운드 2 레이스",

--- a/data/matches/season1/round2-qual.json
+++ b/data/matches/season1/round2-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "round2-qual",
+  "id": "season1-round2-qual",
   "competitionId": "season1",
   "entryId": "season1-round2-qual",
   "name": "라운드 2 퀄리파잉",

--- a/data/matches/season2/final-main.json
+++ b/data/matches/season2/final-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "final-main",
+  "id": "season2-final-main",
   "competitionId": "season2",
   "entryId": "season2-final-main",
   "name": "결승전 레이스",

--- a/data/matches/season2/final-qual.json
+++ b/data/matches/season2/final-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "final-qual",
+  "id": "season2-final-qual",
   "competitionId": "season2",
   "entryId": "season2-final-qual",
   "name": "결승전 퀄리파잉",

--- a/data/matches/season2/pre-a-main.json
+++ b/data/matches/season2/pre-a-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-a-main",
+  "id": "season2-pre-a-main",
   "competitionId": "season2",
   "entryId": "season2-pre-a-main",
   "name": "예선 A조 레이스",

--- a/data/matches/season2/pre-a-qual.json
+++ b/data/matches/season2/pre-a-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-a-qual",
+  "id": "season2-pre-a-qual",
   "competitionId": "season2",
   "entryId": "season2-pre-qual",
   "entryParticipants": 16,

--- a/data/matches/season2/pre-b-main.json
+++ b/data/matches/season2/pre-b-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-b-main",
+  "id": "season2-pre-b-main",
   "competitionId": "season2",
   "entryId": "season2-pre-b-main",
   "name": "예선 B조 레이스",

--- a/data/matches/season2/pre-b-qual.json
+++ b/data/matches/season2/pre-b-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-b-qual",
+  "id": "season2-pre-b-qual",
   "competitionId": "season2",
   "entryId": "season2-pre-qual",
   "entryParticipants": 16,

--- a/data/matches/season2/semifinal-a-main.json
+++ b/data/matches/season2/semifinal-a-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "semifinal-a-main",
+  "id": "season2-semifinal-a-main",
   "competitionId": "season2",
   "entryId": "season2-semifinal-a-main",
   "name": "4강 A조 레이스",

--- a/data/matches/season2/semifinal-a-qual.json
+++ b/data/matches/season2/semifinal-a-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "semifinal-a-qual",
+  "id": "season2-semifinal-a-qual",
   "competitionId": "season2",
   "entryId": "season2-semifinal-a-qual",
   "name": "4강 A조 퀄리파잉",

--- a/data/matches/season2/semifinal-b-main.json
+++ b/data/matches/season2/semifinal-b-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "semifinal-b-main",
+  "id": "season2-semifinal-b-main",
   "competitionId": "season2",
   "entryId": "season2-semifinal-b-main",
   "name": "4강 B조 레이스",

--- a/data/matches/season2/semifinal-b-qual.json
+++ b/data/matches/season2/semifinal-b-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "semifinal-b-qual",
+  "id": "season2-semifinal-b-qual",
   "competitionId": "season2",
   "entryId": "season2-semifinal-b-qual",
   "name": "4강 B조 퀄리파잉",

--- a/data/matches/season2/third-main.json
+++ b/data/matches/season2/third-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "third-main",
+  "id": "season2-third-main",
   "competitionId": "season2",
   "entryId": "season2-third-main",
   "name": "3·4위 결정전 레이스",

--- a/data/matches/season2/third-qual.json
+++ b/data/matches/season2/third-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "third-qual",
+  "id": "season2-third-qual",
   "competitionId": "season2",
   "entryId": "season2-third-qual",
   "name": "3·4위 결정전 퀄리파잉",

--- a/data/matches/season3/pre-a-qual.json
+++ b/data/matches/season3/pre-a-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-a-qual",
+  "id": "season3-pre-a-qual",
   "competitionId": "season3",
   "entryId": "season3-pre-qual",
   "entryParticipants": 30,

--- a/data/matches/season3/pre-b-qual.json
+++ b/data/matches/season3/pre-b-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-b-qual",
+  "id": "season3-pre-b-qual",
   "competitionId": "season3",
   "entryId": "season3-pre-qual",
   "entryParticipants": 30,

--- a/data/matches/season3/pre-c-qual.json
+++ b/data/matches/season3/pre-c-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "pre-c-qual",
+  "id": "season3-pre-c-qual",
   "competitionId": "season3",
   "entryId": "season3-pre-qual",
   "entryParticipants": 30,

--- a/data/matches/season3/stint1-main.json
+++ b/data/matches/season3/stint1-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "stint1-main",
+  "id": "season3-stint1-main",
   "competitionId": "season3",
   "entryId": "season3-stint1-main",
   "name": "STINT 1 레이스",

--- a/data/matches/season3/stint1-qual.json
+++ b/data/matches/season3/stint1-qual.json
@@ -1,5 +1,5 @@
 {
-  "id": "stint1-qual",
+  "id": "season3-stint1-qual",
   "competitionId": "season3",
   "entryId": "season3-stint1-qual",
   "name": "STINT 1 퀄리파잉",

--- a/data/matches/season3/stint2-main.json
+++ b/data/matches/season3/stint2-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "stint2-main",
+  "id": "season3-stint2-main",
   "competitionId": "season3",
   "entryId": "season3-stint2-main",
   "name": "STINT 2 레이스",

--- a/data/matches/season3/stint3-main.json
+++ b/data/matches/season3/stint3-main.json
@@ -1,5 +1,5 @@
 {
-  "id": "stint3-main",
+  "id": "season3-stint3-main",
   "competitionId": "season3",
   "entryId": "season3-stint3-main",
   "name": "STINT 3 레이스",


### PR DESCRIPTION
## Background

- Issue: #51

There are some cases where some matches have same id value.

## Changes

- Include prefix of competition ID in match ID, to avoid duplicate match ID.
