### PR TITLE
[#40] Hide players without rating in leaderboard

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -9,10 +9,11 @@ export default function Leaderboard() {
   const players = loadPlayersById();
 
   const playersWithCurrentRating = Object.entries(players)
+    .filter(([key]) => currentRating[key] !== undefined)
     .map(([key, player]) => {
       return {
         ...player,
-        ...(currentRating[key] ?? { value: Number.MIN_SAFE_INTEGER }),
+        ...currentRating[key],
       };
     })
     .slice()


### PR DESCRIPTION
## Background

- Issue: #40

## Changes

- Add filtering to exclude players without rating data
