### PR TITLE
[#51] Fix wrong pointScheme data in all matches

### DIFF
--- a/data/matches/season1/round1-main.json
+++ b/data/matches/season1/round1-main.json
@@ -6,7 +6,7 @@
   "date": "2025-04-27",
   "type": "MAIN",
   "trackName": "그랜드 밸리 하이웨이 1 (낮)",
-  "pointsSchemeId": "standard",
+  "pointsSchemeId": "default",
   "participants": [
     {
       "id": "namgung-hyuk",

--- a/data/matches/season1/round2-main.json
+++ b/data/matches/season1/round2-main.json
@@ -6,7 +6,7 @@
   "date": "2025-04-27",
   "type": "MAIN",
   "trackName": "도쿄 익스프레스웨이 남쪽 내주 (밤)",
-  "pointsSchemeId": "standard",
+  "pointsSchemeId": "default",
   "participants": [
     {
       "id": "hyungdok",

--- a/data/matches/season2/final-main.json
+++ b/data/matches/season2/final-main.json
@@ -6,7 +6,7 @@
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "몬차 서킷 (시케인 없음)",
-  "pointsSchemeId": "standard",
+  "pointsSchemeId": "default",
   "participants": [
     {
       "id": "namgung-hyuk",

--- a/data/matches/season2/semifinal-a-main.json
+++ b/data/matches/season2/semifinal-a-main.json
@@ -6,7 +6,7 @@
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "레드불 링",
-  "pointsSchemeId": "standard",
+  "pointsSchemeId": "default",
   "participants": [
     {
       "id": "zen1th-hwang",

--- a/data/matches/season2/semifinal-b-main.json
+++ b/data/matches/season2/semifinal-b-main.json
@@ -6,7 +6,7 @@
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "레드불 링",
-  "pointsSchemeId": "standard",
+  "pointsSchemeId": "default",
   "participants": [
     {
       "id": "namgung-hyuk",

--- a/data/matches/season2/third-main.json
+++ b/data/matches/season2/third-main.json
@@ -6,7 +6,7 @@
   "date": "2025-07-06",
   "type": "MAIN",
   "trackName": "몬차 서킷 (시케인 없음)",
-  "pointsSchemeId": "standard",
+  "pointsSchemeId": "default",
   "participants": [
     {
       "id": "park-insoo",


### PR DESCRIPTION
## Background

- Issue: #51

## Changes

- Replace all `standard` scheme ID to `default`