### PR TITLE
[#11|#40] Show tiers as a badge

### DIFF
--- a/app/leaderboard/leaderboardTable.tsx
+++ b/app/leaderboard/leaderboardTable.tsx
@@ -101,8 +101,8 @@ export function LeaderboardTable({ ratingData }: LeaderboardTableProps) {
               </Link>
             </TableCell>
             <TableCell className="text-center">
-              {player.tiers ? (
-                <TierBadge tier={player.tiers[currentSeason]} />
+              {player.tiers?.[currentSeason] ? (
+                <TierBadge tier={player.tiers?.[currentSeason]} />
               ) : (
                 "-"
               )}

--- a/app/players/[id]/page.tsx
+++ b/app/players/[id]/page.tsx
@@ -207,13 +207,7 @@ export default async function Player({
                         <TableRow key={competition.id}>
                           <TableCell>{competition.shortName}</TableCell>
                           <TableCell className="font-semibold">
-                            {player.tiers?.[competition.id] ? (
-                              <TierBadge
-                                tier={player.tiers?.[competition.id]}
-                              />
-                            ) : (
-                              "-"
-                            )}
+                            <TierBadge tier={player.tiers?.[competition.id]} />
                           </TableCell>
                         </TableRow>
                       )

--- a/components/TierBadge.tsx
+++ b/components/TierBadge.tsx
@@ -23,6 +23,6 @@ function styleByTier(tier: Tier): string {
     case Tier.TIER6:
       return "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300";
     default:
-      return "bg-muted text-white";
+      return "bg-muted text-muted-foreground";
   }
 }


### PR DESCRIPTION
## Background

- Issue: #11, #40

## Changes

- Introduce TierBadge component
- Replace plain text tiers in player detail page and leaderboard page to TierBadge