### PR TITLE
[#60] Fix wrong categorized career of season3

### DIFF
--- a/data/players.json
+++ b/data/players.json
@@ -363,7 +363,7 @@
       {
         "type": "major",
         "competitionId": "season3",
-        "category": "team",
+        "category": "individual",
         "detail": "STINT 1 1위"
       }
     ]
@@ -547,7 +547,7 @@
       {
         "type": "major",
         "competitionId": "season3",
-        "category": "team",
+        "category": "individual",
         "detail": "STINT 2 1위"
       }
     ]


### PR DESCRIPTION
## Background

- Issue: #60

## Changes

- Set STINT2 1st and STINT1 1st to individual category
