### PR TITLE
[#128] Add DSQ for participant status

### DIFF
--- a/types/match.ts
+++ b/types/match.ts
@@ -104,7 +104,7 @@ export type MatchRecord = {
    * The status of the participant in the match.
    * E.g., `FINISHED`
    */
-  status: "FINISHED" | "DNF";
+  status: "FINISHED" | "DNF" | "DSQ";
 
   /**
    * The lap time of the participant recorded in qualification stage, in [HH:M]M:SS.mmm format.


### PR DESCRIPTION
## Background

- Issue: #128 

In this competition, now DSQ is available, different from previous competitions

## Changes

- Add DSQ in status enum
