### PR TITLE
[#128] Remove temporary label in season4 matches

### DIFF
--- a/data/entries.json
+++ b/data/entries.json
@@ -124,12 +124,12 @@
     "id": "season4-pre-first-qual",
     "competitionId": "season4",
     "sortKey": 4000100,
-    "note": "제 4회 퍼스트 드라이버 서바이벌 예선 (임시)"
+    "note": "제 4회 퍼스트 드라이버 서바이벌 예선"
   },
   {
     "id": "season4-pre-second-qual",
     "competitionId": "season4",
     "sortKey": 4000200,
-    "note": "제 4회 세컨드 드라이버 서바이벌 예선 (임시)"
+    "note": "제 4회 세컨드 드라이버 서바이벌 예선"
   }
 ]

--- a/data/matches/season4/final-main.json
+++ b/data/matches/season4/final-main.json
@@ -2,7 +2,7 @@
   "id": "season4-final-main",
   "competitionId": "season4",
   "entryId": "season4-final-main",
-  "name": "파이널 레이스 (임시)",
+  "name": "파이널 레이스",
   "date": "2026-03-08",
   "type": "MAIN",
   "kind": "TEAM",

--- a/data/matches/season4/final-qual.json
+++ b/data/matches/season4/final-qual.json
@@ -2,7 +2,7 @@
   "id": "season4-final-qual",
   "competitionId": "season4",
   "entryId": "season4-final-qual",
-  "name": "파이널 퀄리파잉 (임시)",
+  "name": "파이널 퀄리파잉",
   "date": "2026-03-08",
   "type": "QUALIFYING",
   "kind": "TEAM",

--- a/data/matches/season4/pre-first-qual.json
+++ b/data/matches/season4/pre-first-qual.json
@@ -2,7 +2,7 @@
   "id": "season4-pre-first-qual",
   "competitionId": "season4",
   "entryId": "season4-pre-first-qual",
-  "name": "퍼스트 드라이버 서바이벌 예선 (임시)",
+  "name": "퍼스트 드라이버 서바이벌 예선",
   "date": "2026-03-03",
   "type": "QUALIFYING",
   "kind": "INDIVIDUAL",

--- a/data/matches/season4/pre-second-a-qual.json
+++ b/data/matches/season4/pre-second-a-qual.json
@@ -3,7 +3,7 @@
   "competitionId": "season4",
   "entryId": "season4-pre-second-qual",
   "entryParticipants": 26,
-  "name": "세컨드 드라이버 서바이벌 예선 A조 (임시)",
+  "name": "세컨드 드라이버 서바이벌 예선 A조",
   "date": "2026-03-03",
   "type": "QUALIFYING",
   "kind": "INDIVIDUAL",

--- a/data/matches/season4/pre-second-b-qual.json
+++ b/data/matches/season4/pre-second-b-qual.json
@@ -3,7 +3,7 @@
   "competitionId": "season4",
   "entryId": "season4-pre-second-qual",
   "entryParticipants": 26,
-  "name": "세컨드 드라이버 서바이벌 예선 B조 (임시)",
+  "name": "세컨드 드라이버 서바이벌 예선 B조",
   "date": "2026-03-03",
   "type": "QUALIFYING",
   "kind": "INDIVIDUAL",

--- a/data/matches/season4/round1-main.json
+++ b/data/matches/season4/round1-main.json
@@ -2,7 +2,7 @@
   "id": "season4-round1-main",
   "competitionId": "season4",
   "entryId": "season4-round1-main",
-  "name": "1라운드 레이스 (임시)",
+  "name": "1라운드 레이스",
   "date": "2026-03-07",
   "type": "MAIN",
   "kind": "TEAM",

--- a/data/matches/season4/round1-qual.json
+++ b/data/matches/season4/round1-qual.json
@@ -2,7 +2,7 @@
   "id": "season4-round1-qual",
   "competitionId": "season4",
   "entryId": "season4-round1-qual",
-  "name": "1라운드 퀄리파잉 (임시)",
+  "name": "1라운드 퀄리파잉",
   "date": "2026-03-07",
   "type": "QUALIFYING",
   "kind": "TEAM",

--- a/data/matches/season4/round2-main.json
+++ b/data/matches/season4/round2-main.json
@@ -2,7 +2,7 @@
   "id": "season4-round2-main",
   "competitionId": "season4",
   "entryId": "season4-round2-main",
-  "name": "2라운드 레이스 (임시)",
+  "name": "2라운드 레이스",
   "date": "2026-03-07",
   "type": "MAIN",
   "kind": "TEAM",


### PR DESCRIPTION
## Background

- Issue: #128

## Changes

- Remove "(임시") in all season4 matches and entries
