### PR TITLE
[#128] Add missing penalty time of park-insoo in season4 final main match

### DIFF
--- a/data/matches/season4/final-main.json
+++ b/data/matches/season4/final-main.json
@@ -137,7 +137,11 @@
       "teamId": "season4-mercedes",
       "place": 20,
       "bonusPoints": 1,
-      "record": { "status": "FINISHED", "finishTime": "+1 Lap" }
+      "record": {
+        "status": "FINISHED",
+        "finishTime": "+1 Lap",
+        "penaltyTime": "00:03.000"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Background

- Issue: #128
- Resolves #128

## Changes

- Add penalty time of 00:03.000 to park-insoo in season4 final main match