### PR TITLE
[#60] Render operator career as a etc. field in player detail page

### DIFF
--- a/data/players.json
+++ b/data/players.json
@@ -65,7 +65,13 @@
         "type": "major",
         "competitionId": "season4",
         "category": "team",
-        "detail": "2위(op)"
+        "detail": "2위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -366,7 +372,13 @@
         "type": "minor",
         "competitionId": "season4",
         "category": "team",
-        "detail": "7위(op)"
+        "detail": "7위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -430,7 +442,13 @@
         "type": "major",
         "competitionId": "season4",
         "category": "team",
-        "detail": "3위(op)"
+        "detail": "3위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -724,7 +742,13 @@
         "type": "minor",
         "competitionId": "season4",
         "category": "team",
-        "detail": "5위(op)"
+        "detail": "5위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -968,7 +992,13 @@
         "type": "minor",
         "competitionId": "season4",
         "category": "team",
-        "detail": "6위(op)"
+        "detail": "6위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -1026,7 +1056,13 @@
         "type": "major",
         "competitionId": "season4",
         "category": "team",
-        "detail": "우승(op)"
+        "detail": "우승"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -1092,7 +1128,13 @@
         "type": "minor",
         "competitionId": "season4",
         "category": "team",
-        "detail": "4위(op)"
+        "detail": "4위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ]
   },
@@ -1120,7 +1162,13 @@
         "type": "minor",
         "competitionId": "season4",
         "category": "team",
-        "detail": "6위(op)"
+        "detail": "10위"
+      },
+      {
+        "type": "minor",
+        "competitionId": "season4",
+        "category": "individual",
+        "detail": "오퍼레이터"
       }
     ],
     "isNotPlayer": true


### PR DESCRIPTION
## Background

- Issue: #60

## Changes

- Separate career of operators in season4 as an individual career
