### PR TITLE
[#128] Add career of participating season4's preliminary stage

### DIFF
--- a/data/players.json
+++ b/data/players.json
@@ -218,12 +218,6 @@
         "competitionId": "season3",
         "category": "team",
         "detail": "3위"
-      },
-      {
-        "type": "minor",
-        "competitionId": "season4",
-        "category": "team",
-        "detail": "예선 참가"
       }
     ]
   },


### PR DESCRIPTION
## Background

- Issue: #128

## Changes

- Add "예선 참가" career to all players who participated in preliminary stage in season4 but not in main stage