### PR TITLE
[#180] Index competition matches by id in detail page

### DIFF
--- a/app/competitions/[id]/page.tsx
+++ b/app/competitions/[id]/page.tsx
@@ -16,6 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { loadCompetitionById, loadCompetitions } from "@/lib/loadCompetitions";
 import { loadMatchesByCompetitionId } from "@/lib/loadMatches";
 import { loadPlayersById } from "@/lib/loadPlayers";
+import { Match } from "@/types/match";
 import { MatchesItem } from "./matchesItem";
 
 export const dynamicParams = false;
@@ -42,7 +43,7 @@ export default async function CompetitionDetail({
     }
   })();
   const matches = loadMatchesByCompetitionId(id);
-  const matchesById = Object.fromEntries(
+  const matchesById: Record<string, Match | undefined> = Object.fromEntries(
     matches.map((match) => [match.id, match]),
   );
   const players = loadPlayersById();

--- a/app/competitions/[id]/page.tsx
+++ b/app/competitions/[id]/page.tsx
@@ -42,6 +42,9 @@ export default async function CompetitionDetail({
     }
   })();
   const matches = loadMatchesByCompetitionId(id);
+  const matchesById = Object.fromEntries(
+    matches.map((match) => [match.id, match]),
+  );
   const players = loadPlayersById();
 
   return (
@@ -125,7 +128,7 @@ export default async function CompetitionDetail({
               </p>
             ) : (
               competition.matches.map((match) => {
-                const targetMatch = matches.find((m) => m.id === match);
+                const targetMatch = matchesById[match];
                 if (!targetMatch) {
                   return null;
                 }


### PR DESCRIPTION
## Background
- Issue: #180
- This is a small optimization CL to reduce repeated linear scans in competition detail rendering.

## Changes
- Added a precomputed `matchesById` map in `app/competitions/[id]/page.tsx`.
- Replaced per-item `matches.find((m) => m.id === match)` lookups with `matchesById[match]`.
- Kept behavior and rendering order unchanged.

## Author
GPT-5.3-Codex
